### PR TITLE
[Feature] - Owner Order Actions

### DIFF
--- a/frontend/src/components/order/OrderActions.jsx
+++ b/frontend/src/components/order/OrderActions.jsx
@@ -10,25 +10,25 @@ const iconMap = {
   approve: { icon: "bi-check-lg", color: "#28a745" },
   reject: { icon: "bi-x-lg", color: "#dc3545" },
   pay: { icon: "bi-cash-coin", color: "#0d6efd" },
-  complete: { icon: "bi-truck", color: "#ffc107" },
+  complete: { icon: "bi-box-seam", color: "#ffc107" },
+  deliver: { icon: "bi-box-seam", color: "#ffc107" },
   cancel: { icon: "bi-x-octagon", color: "#FF0000" },
   delete: { icon: "bi-trash", color: "#f10d0dff" },
 };
 
 const OrderActions = ({ actions, orderId, refreshOrders, hideDetailAction = false }) => {
   if (!actions || actions.length === 0) return null;
-
   const [modalOpen, setModalOpen] = useState(false);
   const [currentAction, setCurrentAction] = useState(null);
   const [showDetailModal, setShowDetailModal] = useState(false);
   const { authToken } = useContext(AuthContext);
 
   const filteredActions = hideDetailAction
-    ? actions.filter(action => action !== "view_details")
+    ?
+    actions.filter(action => action !== "view_details")
     : actions;
 
   if (filteredActions.length === 0) return null;
-
   const handleActionClick = (action) => {
     if (action === "view_details") {
       if (!orderId) {
@@ -52,7 +52,6 @@ const OrderActions = ({ actions, orderId, refreshOrders, hideDetailAction = fals
     setModalOpen(false);
     setCurrentAction(null);
   };
-
   const handleConfirm = async () => {
     try {
       if (!currentAction) return;
@@ -63,26 +62,24 @@ const OrderActions = ({ actions, orderId, refreshOrders, hideDetailAction = fals
           response = await payOrder(orderId, authToken);
           Toast({ icon: "success", title: response?.message || "Order paid successfully" });
           break;
-
         case "cancel":
           response = await cancelOrder(orderId, authToken);
           Toast({ icon: "warning", title: response?.message || "Order cancelled successfully" });
           break;
-
         case "approve":
           response = await approveOrder(orderId, authToken);
           Toast({ icon: "success", title: response?.message || "Order approved successfully" });
           break;
-
         case "reject":
           response = await rejectOrder(orderId, authToken);
           Toast({ icon: "error", title: response?.message || "Order rejected successfully" });
           break;
-
+        case "deliver":
+          Toast({ icon: "info", title: "Deliver action not implemented in the service yet" });
+          break;
         default:
           Toast({ icon: "info", title: "Action not implemented yet" });
       }
-
       if (refreshOrders) await refreshOrders();
     } catch (error) {
       console.error("Order action error:", error);
@@ -90,7 +87,6 @@ const OrderActions = ({ actions, orderId, refreshOrders, hideDetailAction = fals
       const msg =
         error.response?.data?.message ||
         (status === 500 ? "Server error: please try again later." : "Error performing action");
-
       Toast({ icon: "error", title: "Error", text: msg });
     } finally {
       setModalOpen(false);
@@ -100,19 +96,19 @@ const OrderActions = ({ actions, orderId, refreshOrders, hideDetailAction = fals
 
   const confirmVariant =
     ["reject", "delete", "cancel"].includes(currentAction?.name)
-      ? "danger"
+      ?
+      "danger"
       : ["approve"].includes(currentAction?.name)
-        ? "success"
+        ?
+        "success"
         : "primary";
-
   const customButtonStyle =
     currentAction?.name === "approve"
-      ? { backgroundColor: "#0ab432ff", border: "none", color: "#fff" }
+      ?
+      { backgroundColor: "#0ab432ff", border: "none", color: "#fff" }
       : {};
-
   const formattedAction = currentAction?.name?.replace("_", " ") || "";
   const actionIcon = currentAction?.icon || "bi-question";
-
   return (
     <>
       <div className="d-flex flex-wrap justify-content-center gap-2">
@@ -122,6 +118,7 @@ const OrderActions = ({ actions, orderId, refreshOrders, hideDetailAction = fals
             color: "#6c757d",
           };
           return (
+
             <button
               key={action}
               className="border-0 d-flex align-items-center justify-content-center"
@@ -129,12 +126,14 @@ const OrderActions = ({ actions, orderId, refreshOrders, hideDetailAction = fals
               style={{
                 width: "36px",
                 height: "36px",
+
                 borderRadius: "8px",
                 backgroundColor: color,
                 color: "#fff",
                 transition: "transform 0.1s ease-in-out",
               }}
               title={action.replace("_", " ")}
+
               onMouseEnter={(e) => (e.currentTarget.style.transform = "scale(1.1)")}
               onMouseLeave={(e) => (e.currentTarget.style.transform = "scale(1)")}
             >
@@ -152,23 +151,27 @@ const OrderActions = ({ actions, orderId, refreshOrders, hideDetailAction = fals
         >
           <div className="modal-dialog modal-dialog-centered">
             <div className="modal-content border-0 text-center">
+
               <div className="modal-header border-0">
                 <h5 className="modal-title w-100">Confirm Action</h5>
               </div>
               <div className="modal-body">
                 <p>Are you sure you want to {formattedAction}?</p>
               </div>
+
               <div className="modal-footer border-0 justify-content-end gap-2">
                 <Button variant="secondary" onClick={handleCancel}>
                   Go Back
                 </Button>
                 <Button
+
                   variant={confirmVariant}
                   onClick={handleConfirm}
                   style={customButtonStyle}
                 >
                   <i className={`bi ${actionIcon} me-2`}></i>
                   Confirm
+
                 </Button>
               </div>
             </div>
@@ -180,6 +183,7 @@ const OrderActions = ({ actions, orderId, refreshOrders, hideDetailAction = fals
         <OrderDetailModal
           orderId={orderId}
           actions={actions}
+
           refreshOrders={refreshOrders}
           onClose={() => setShowDetailModal(false)}
         />

--- a/frontend/src/components/order/OrderActions.jsx
+++ b/frontend/src/components/order/OrderActions.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useContext } from "react";
 import Button from "../Button.jsx";
 import { AuthContext } from "../../context/AuthContext.jsx";
-import { payOrder, cancelOrder } from "../../services/OrderActions.js";
+import { payOrder, cancelOrder, approveOrder, rejectOrder } from "../../services/OrderActions.js";
 import Toast from "../../utils/Toast.js";
 import OrderDetailModal from "./OrderDetailModal.jsx";
 
@@ -23,7 +23,7 @@ const OrderActions = ({ actions, orderId, refreshOrders, hideDetailAction = fals
   const [showDetailModal, setShowDetailModal] = useState(false);
   const { authToken } = useContext(AuthContext);
 
-  const filteredActions = hideDetailAction 
+  const filteredActions = hideDetailAction
     ? actions.filter(action => action !== "view_details")
     : actions;
 
@@ -70,11 +70,13 @@ const OrderActions = ({ actions, orderId, refreshOrders, hideDetailAction = fals
           break;
 
         case "approve":
-          Toast({ icon: "info", title: "This functionality has not been developed yet" });
+          response = await approveOrder(orderId, authToken);
+          Toast({ icon: "success", title: response?.message || "Order approved successfully" });
           break;
 
         case "reject":
-          Toast({ icon: "info", title: "This functionality has not been developed yet" });
+          response = await rejectOrder(orderId, authToken);
+          Toast({ icon: "error", title: response?.message || "Order rejected successfully" });
           break;
 
         default:
@@ -100,8 +102,8 @@ const OrderActions = ({ actions, orderId, refreshOrders, hideDetailAction = fals
     ["reject", "delete", "cancel"].includes(currentAction?.name)
       ? "danger"
       : ["approve"].includes(currentAction?.name)
-      ? "success"
-      : "primary";
+        ? "success"
+        : "primary";
 
   const customButtonStyle =
     currentAction?.name === "approve"

--- a/frontend/src/components/order/OrdersTable.jsx
+++ b/frontend/src/components/order/OrdersTable.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import OrderActions from "./OrderActions.jsx";
 
-const OrdersTable = ({ orders }) => {
+const OrdersTable = ({ orders, refreshOrders }) => {
   if (!orders || orders.length === 0)
     return <p className="text-center mt-4 text-muted">No orders found.</p>;
 
@@ -86,7 +86,7 @@ const OrdersTable = ({ orders }) => {
                   <OrderActions
                     actions={order.actions}
                     orderId={order._id || order.id}
-                    refreshOrders={null}
+                    refreshOrders={refreshOrders}
                   />
                 </td>
               </tr>

--- a/frontend/src/pages/orders/ShopOrders.jsx
+++ b/frontend/src/pages/orders/ShopOrders.jsx
@@ -16,37 +16,37 @@ const ShopOrders = () => {
   const [loading, setLoading] = useState(true);
   const [showModal, setShowModal] = useState(false);
 
+  const fetchData = async () => {
+    try {
+      const ordersData = await getShopOrders(shopId, authToken);
+      setOrders(ordersData);
+
+      const shopRes = await axios.get(`${baseURL()}/api/shops`, {
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+
+      const shopList = shopRes.data?.shops || [];
+      const currentShop = shopList.find((s) => s._id === shopId);
+
+      setShopName(currentShop ? currentShop.name : "Unnamed Shop");
+    } catch (error) {
+      console.error(error);
+      Toast({
+        icon: "error",
+        title: "Error",
+        text: "Unable to fetch shop or orders.",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
   useEffect(() => {
     if (currentUser.role !== "business_owner") {
       setShowModal(true);
       setLoading(false);
       return;
     }
-
-    const fetchData = async () => {
-      try {
-        const ordersData = await getShopOrders(shopId, authToken);
-        setOrders(ordersData);
-
-        const shopRes = await axios.get(`${baseURL()}/api/shops`, {
-          headers: { Authorization: `Bearer ${authToken}` },
-        });
-
-        const shopList = shopRes.data?.shops || [];
-        const currentShop = shopList.find((s) => s._id === shopId);
-
-        setShopName(currentShop ? currentShop.name : "Unnamed Shop");
-      } catch (error) {
-        console.error(error);
-        Toast({
-          icon: "error",
-          title: "Error",
-          text: "Unable to fetch shop or orders.",
-        });
-      } finally {
-        setLoading(false);
-      }
-    };
 
     fetchData();
   }, [shopId, authToken, currentUser]);
@@ -102,7 +102,10 @@ const ShopOrders = () => {
               <p className="mt-2">Loading orders...</p>
             </div>
           ) : (
-            <OrdersTable orders={orders} />
+            <OrdersTable 
+              orders={orders}
+              refreshOrders={fetchData}
+            />
           )}
         </>
       )}

--- a/frontend/src/services/OrderActions.js
+++ b/frontend/src/services/OrderActions.js
@@ -19,3 +19,23 @@ export const cancelOrder = async (orderId, token) => {
   );
   return response.data;
 };
+
+
+export const approveOrder = async (orderId, token) => {
+  const response = await axios.patch(
+    `${baseURL()}/api/orders/approve/${orderId}`,
+    {},
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  return response.data;
+};
+
+
+export const rejectOrder = async (orderId, token) => {
+  const response = await axios.patch(
+    `${baseURL()}/api/orders/reject/${orderId}`,
+    {},
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  return response.data;
+};


### PR DESCRIPTION
Esta implementación habilita a los usuarios `business_owner` a gestionar el flujo de las órdenes de compra.

### Changes

* **Implementación de Acciones Críticas:**
    * Se implementaron las funciones `approveOrder` y `rejectOrder` en el servicio `OrderActions.js` para consumir los endpoints `PATCH` correspondientes en el backend.
    * La lógica de `handleConfirm` en `OrderActions.jsx` fue extendida para invocar estas nuevas acciones.
    
* **Refresco Automático (UX):**
    * Se resolvió el refresh manual. La función de carga de datos (`fetchData`) fue movida y pasada como callback `refreshOrders` en `ShopOrders.jsx`.
    * `OrderActions.jsx` ahora utiliza esta prop para recargar la lista de órdenes automáticamente tras un éxito, asegurando la actualización inmediata del estado en la tabla.
* **Mejora Visual de Acciones:**
    * Se actualizó el `iconMap` en `OrderActions.jsx` para asignar el color amarillo y el ícono de entrega a las acciones de `complete` y `deliver`

#### Archivos Modificados

* `src/services/OrderActions.js`
* `src/components/order/OrderActions.jsx`
* `src/pages/orders/ShopOrders.jsx`
* `src/components/order/OrdersTable.jsx` 